### PR TITLE
set separate cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # Bazel distributed cache, can be temporarily disabled by passing the following
 # flag: --noremote_accept_cached
-build:darwin --remote_http_cache=https://bazel-cache.da-ext.net
-build:linux --remote_http_cache=https://bazel-cache.da-ext.net/ubuntu_20_04
+build:darwin --remote_http_cache=https://bazel-cache.da-ext.net/json-api/2022-04-21/darwin
+build:linux --remote_http_cache=https://bazel-cache.da-ext.net/json-api/2022-04-21/linux
 # Don't push local build results to the remote cache.
 build --remote_upload_local_results=false
 # Do still push local build results to the local disk cache.

--- a/ci/check-protobuf-stability.sh
+++ b/ci/check-protobuf-stability.sh
@@ -88,6 +88,10 @@ USAGE
   # This check does not need to run on release branch commits because
   # they are built sequentially, so no conflicts are possible and the per-PR
   # check is enough.
+  if [ 0 == "$(git tag | wc -l)" ]; then
+      echo "No tag, no check."
+      exit 0
+  fi
   readonly RELEASE_BRANCH_REGEX="^release/.*"
   LATEST_STABLE_TAG=""
   if [[ "${TARGET}" =~ ${RELEASE_BRANCH_REGEX} ]]; then

--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -48,7 +48,7 @@ if [ ! -z "${BAZEL_CONFIG_DIR:-}" ]; then
     cd "$BAZEL_CONFIG_DIR"
 fi
 
-CACHE_URL="https://storage.googleapis.com/daml-bazel-cache"
+CACHE_URL="https://storage.googleapis.com/daml-bazel-cache/json-api/2022-04-21/$os"
 
 if is_windows; then
   echo "build --config windows" > .bazelrc.local
@@ -76,7 +76,7 @@ if is_windows; then
   # We include an extra version at the end that we can bump manually.
   CACHE_SUFFIX="$SUFFIX-v12"
   CACHE_URL="$CACHE_URL/$CACHE_SUFFIX"
-  echo "build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net/$CACHE_SUFFIX" >> .bazelrc.local
+  echo "build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net/json-api/2022-04-21/windows/$CACHE_SUFFIX" >> .bazelrc.local
 fi
 
 # sets up write access to the shared remote cache if the branch is not a fork

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -1,7 +1,7 @@
 # Bazel distributed cache, can be temporarily disabled by passing the following
 # flag: --noremote_accept_cached
-build:darwin --remote_http_cache=https://bazel-cache.da-ext.net
-build:linux --remote_http_cache=https://bazel-cache.da-ext.net/ubuntu_20_04
+build:darwin --remote_http_cache=https://bazel-cache.da-ext.net/json-api/2022-04-21/darwin
+build:linux --remote_http_cache=https://bazel-cache.da-ext.net/json-api/2022-04-21/linux
 # Don't push local build results to the remote cache.
 build --remote_upload_local_results=false
 # Do still push local build results to the local disk cache.


### PR DESCRIPTION
We've seen enough weird things happening with the daml cache that I
don't want to add the possibility of cross-repository corruption.

Hopefully we don't use Bazel on this side for long enough that this
would happen, but better safe than sorry.

CHANGELOG_BEGIN
CHANGELOG_END